### PR TITLE
fix: state not change  when component destroy

### DIFF
--- a/src/CascadeSelect.jsx
+++ b/src/CascadeSelect.jsx
@@ -98,6 +98,7 @@ class CascadeSelect extends SuperComponent {
         const state = CascadeSelect.returnMultiState(selectedOptions) || {};
         if (newState && newState.options) {
           state.options = newState.options;
+          state.preOptions = newState.preOptions;
           state.loadedOptions = newState.loadedOptions;
         }
         if (newState && newState.value) {


### PR DESCRIPTION
修复当组件被销毁时，再此启用，getderivefromepops声明周期函数处理state时异常